### PR TITLE
Improve how device are selected.

### DIFF
--- a/include/audio/driver/alsa.h
+++ b/include/audio/driver/alsa.h
@@ -102,7 +102,6 @@ class Alsa final : public Playback {
 
   /* ******************************************************************************************** */
   //! Default Constants for Audio Parameters
-  static constexpr const char kDevice[] = "default";
   static constexpr const char kSelemName[] = "Master";
   static constexpr int kChannels = 2;
   static constexpr int kSampleRate = 44100;


### PR DESCRIPTION
When using the "default" device name, there was an error: "Cannot open slave". I don't really know why...

When using "pulse", it was working.

This patch:
- List the available devices.
- Reorder the list to make "default" prefered, followed by "pulse".
- Try opening each device until finding one working.