### PR TITLE
Add support to play next file when song has ended

### DIFF
--- a/include/model/song.h
+++ b/include/model/song.h
@@ -34,6 +34,7 @@ struct Song {
     Play = 2002,
     Pause = 2003,
     Stop = 2004,
+    Finished = 2005
   };
 
   struct CurrentInformation {

--- a/include/view/block/list_directory.h
+++ b/include/view/block/list_directory.h
@@ -33,6 +33,7 @@ class ListDirectoryTest_RunTextAnimation_Test;
 class ListDirectoryTest_ScrollMenuOnBigList_Test;
 class ListDirectoryTest_TabMenuOnBigList_Test;
 class ListDirectoryTest_PlayNextFileAfterFinished_Test;
+class ListDirectoryTest_StartPlayingLastFileAndPlayNextAfterFinished_Test;
 class ListDirectoryCtorTest;
 class ListDirectoryCtorTest_CreateWithBadInitialPath_Test;
 }  // namespace
@@ -293,6 +294,7 @@ class ListDirectory : public Block {
   FRIEND_TEST(::ListDirectoryTest, ScrollMenuOnBigList);
   FRIEND_TEST(::ListDirectoryTest, TabMenuOnBigList);
   FRIEND_TEST(::ListDirectoryTest, PlayNextFileAfterFinished);
+  FRIEND_TEST(::ListDirectoryTest, StartPlayingLastFileAndPlayNextAfterFinished);
   FRIEND_TEST(::ListDirectoryCtorTest, CreateWithBadInitialPath);
 #endif
 };

--- a/include/view/block/list_directory.h
+++ b/include/view/block/list_directory.h
@@ -32,6 +32,7 @@ class ListDirectoryTest;
 class ListDirectoryTest_RunTextAnimation_Test;
 class ListDirectoryTest_ScrollMenuOnBigList_Test;
 class ListDirectoryTest_TabMenuOnBigList_Test;
+class ListDirectoryTest_PlayNextFileAfterFinished_Test;
 class ListDirectoryCtorTest;
 class ListDirectoryCtorTest_CreateWithBadInitialPath_Test;
 }  // namespace
@@ -148,6 +149,7 @@ class ListDirectory : public Block {
 
   /* ******************************************************************************************** */
   //! File list operations
+
   /**
    * TODO: move this to a controller?
    * @brief Refresh list with all files from the given directory path
@@ -165,6 +167,12 @@ class ListDirectory : public Block {
    * @brief Update content from active entry (decides if animation thread should run or not)
    */
   void UpdateActiveEntry();
+
+  /**
+   * @brief Select next file to play
+   * @return Filepath
+   */
+  File SelectNextToPlay();
 
   /* ******************************************************************************************** */
  protected:
@@ -284,6 +292,7 @@ class ListDirectory : public Block {
   FRIEND_TEST(::ListDirectoryTest, RunTextAnimation);
   FRIEND_TEST(::ListDirectoryTest, ScrollMenuOnBigList);
   FRIEND_TEST(::ListDirectoryTest, TabMenuOnBigList);
+  FRIEND_TEST(::ListDirectoryTest, PlayNextFileAfterFinished);
   FRIEND_TEST(::ListDirectoryCtorTest, CreateWithBadInitialPath);
 #endif
 };

--- a/src/view/block/list_directory.cc
+++ b/src/view/block/list_directory.cc
@@ -520,17 +520,17 @@ void ListDirectory::UpdateActiveEntry() {
 File ListDirectory::SelectNextToPlay() {
   if (entries_.size() <= 2) return File{};
 
-  // get index from current song playing
-  int index =
-      std::distance(entries_.begin(), std::find(entries_.begin(), entries_.end(), *curr_playing_));
+  // Get index from current song playing
+  int index = (int)std::distance(entries_.begin(),
+                                 std::find(entries_.begin(), entries_.end(), *curr_playing_));
 
   int next = (index + 1) % entries_.size();
-  int attempts = entries_.size();
+  int attempts = (int)entries_.size();
   File file;
 
   // Iterate circularly through all file entries
   bool found = false;
-  while (file = entries_[next], attempts > 0) {
+  for (file = entries_[next]; attempts > 0; --attempts, file = entries_[next]) {
     // Found a possible file to play
     if (next != 0 && file != *curr_playing_ && !std::filesystem::is_directory(file)) {
       found = true;
@@ -538,7 +538,6 @@ File ListDirectory::SelectNextToPlay() {
     }
 
     next = (next + 1) % entries_.size();
-    --attempts;
   }
 
   return found ? file : File{};

--- a/src/view/block/list_directory.cc
+++ b/src/view/block/list_directory.cc
@@ -521,11 +521,11 @@ File ListDirectory::SelectNextToPlay() {
   if (entries_.size() <= 2) return File{};
 
   // Get index from current song playing
-  int index = (int)std::distance(entries_.begin(),
-                                 std::find(entries_.begin(), entries_.end(), *curr_playing_));
+  auto index = (int)std::distance(entries_.begin(),
+                                  std::find(entries_.begin(), entries_.end(), *curr_playing_));
 
   int next = (index + 1) % entries_.size();
-  int attempts = (int)entries_.size();
+  auto attempts = (int)entries_.size();
   File file;
 
   // Iterate circularly through all file entries

--- a/src/view/block/media_player.cc
+++ b/src/view/block/media_player.cc
@@ -263,11 +263,10 @@ bool MediaPlayer::OnCustomEvent(const CustomEvent& event) {
     song_ = event.GetContent<model::Song>();
   }
 
+  // Do not return true because other blocks may use it
   if (event == CustomEvent::Identifier::UpdateSongState) {
     song_.curr_info = event.GetContent<model::Song::CurrentInformation>();
     if (song_.curr_info.state == model::Song::MediaState::Play) btn_play_->SetState(true);
-
-    return true;
   }
 
   return false;

--- a/test/audio_player.cc
+++ b/test/audio_player.cc
@@ -134,7 +134,10 @@ TEST_F(PlayerTest, CreatePlayerAndStartPlaying) {
     EXPECT_CALL(*notifier, NotifySongState(model::Song::CurrentInformation{
                                .state = model::Song::MediaState::Play, .position = 0}));
 
+    // These are called by Player::ResetMediaControl()
     EXPECT_CALL(*decoder, ClearCache());
+    EXPECT_CALL(*notifier, NotifySongState(model::Song::CurrentInformation{
+                               .state = model::Song::MediaState::Finished}));
     EXPECT_CALL(*notifier, ClearSongInformation(true)).WillOnce(Invoke([&] {
       syncer.NotifyStep(2);
     }));
@@ -215,7 +218,10 @@ TEST_F(PlayerTest, StartPlayingAndPause) {
                 NotifySongState(Field(&model::Song::CurrentInformation::state, State::Pause)))
         .WillOnce(Invoke([&] { syncer.NotifyStep(4); }));
 
+    // These are called by Player::ResetMediaControl()
     EXPECT_CALL(*decoder, ClearCache());
+    EXPECT_CALL(*notifier, NotifySongState(model::Song::CurrentInformation{
+                               .state = model::Song::MediaState::Finished}));
     EXPECT_CALL(*notifier, ClearSongInformation(true)).WillOnce(Invoke([&] {
       syncer.NotifyStep(5);
     }));
@@ -364,7 +370,10 @@ TEST_F(PlayerTest, StartPlayingAndUpdateSongState) {
     EXPECT_CALL(*notifier, NotifySongState(Field(&model::Song::CurrentInformation::position,
                                                  expected_position)));
 
+    // These are called by Player::ResetMediaControl()
     EXPECT_CALL(*decoder, ClearCache());
+    EXPECT_CALL(*notifier, NotifySongState(model::Song::CurrentInformation{
+                               .state = model::Song::MediaState::Finished}));
     EXPECT_CALL(*notifier, ClearSongInformation(true)).WillOnce(Invoke([&] {
       syncer.NotifyStep(2);
     }));
@@ -565,7 +574,10 @@ TEST_F(PlayerTest, StartPlayingSeekForwardAndBackward) {
     EXPECT_CALL(*playback, AudioCallback(_, _)).Times(2);
     EXPECT_CALL(*notifier, NotifySongState(_)).Times(2);
 
+    // These are called by Player::ResetMediaControl()
     EXPECT_CALL(*decoder, ClearCache());
+    EXPECT_CALL(*notifier, NotifySongState(model::Song::CurrentInformation{
+                               .state = model::Song::MediaState::Finished}));
     EXPECT_CALL(*notifier, ClearSongInformation(true)).WillOnce(Invoke([&] {
       syncer.NotifyStep(4);
     }));
@@ -658,7 +670,10 @@ TEST_F(PlayerTest, TryToSeekWhilePaused) {
                 NotifySongState(Field(&model::Song::CurrentInformation::state, State::Pause)))
         .WillOnce(Invoke([&] { syncer.NotifyStep(4); }));
 
+    // These are called by Player::ResetMediaControl()
     EXPECT_CALL(*decoder, ClearCache());
+    EXPECT_CALL(*notifier, NotifySongState(model::Song::CurrentInformation{
+                               .state = model::Song::MediaState::Finished}));
     EXPECT_CALL(*notifier, ClearSongInformation(true)).WillOnce(Invoke([&] {
       syncer.NotifyStep(5);
     }));
@@ -746,7 +761,10 @@ TEST_F(PlayerTest, StartPlayingAndRequestNewSong) {
     EXPECT_CALL(*notifier, NotifySongState(Field(&model::Song::CurrentInformation::position,
                                                  expected_position)));
 
+    // These are called by Player::ResetMediaControl()
     EXPECT_CALL(*decoder, ClearCache());
+    EXPECT_CALL(*notifier, NotifySongState(model::Song::CurrentInformation{
+                               .state = model::Song::MediaState::Finished}));
     EXPECT_CALL(*notifier, ClearSongInformation(true)).WillOnce(Invoke([&] {
       /* ************************************************************************************** */
       // ATTENTION: this is the workaround found to iterate in a new audio loop to play (using the
@@ -781,7 +799,10 @@ TEST_F(PlayerTest, StartPlayingAndRequestNewSong) {
                                                    expected_position)))
           .Times(0);
 
+      // These are called by Player::ResetMediaControl()
       EXPECT_CALL(*decoder, ClearCache());
+      EXPECT_CALL(*notifier, NotifySongState(model::Song::CurrentInformation{
+                                 .state = model::Song::MediaState::Finished}));
       EXPECT_CALL(*notifier, ClearSongInformation(true));
     }));
 
@@ -872,7 +893,10 @@ TEST_F(PlayerTest, StartPlayingThenPauseAndRequestNewSong) {
     EXPECT_CALL(*notifier, NotifySongState(Field(&model::Song::CurrentInformation::state,
                                                  model::Song::MediaState::Pause)));
 
+    // These are called by Player::ResetMediaControl()
     EXPECT_CALL(*decoder, ClearCache());
+    EXPECT_CALL(*notifier, NotifySongState(model::Song::CurrentInformation{
+                               .state = model::Song::MediaState::Finished}));
     EXPECT_CALL(*notifier, ClearSongInformation(true)).WillOnce(Invoke([&] {
       /* ************************************************************************************** */
       // ATTENTION: this is the workaround found to iterate in a new audio loop to play (using the
@@ -907,7 +931,10 @@ TEST_F(PlayerTest, StartPlayingThenPauseAndRequestNewSong) {
                                                    expected_position)))
           .Times(0);
 
+      // These are called by Player::ResetMediaControl()
       EXPECT_CALL(*decoder, ClearCache());
+      EXPECT_CALL(*notifier, NotifySongState(model::Song::CurrentInformation{
+                                 .state = model::Song::MediaState::Finished}));
       EXPECT_CALL(*notifier, ClearSongInformation(true));
     }));
 
@@ -1003,7 +1030,10 @@ TEST_F(PlayerTest, StartPlayingThenPauseAndUpdateAudioFilters) {
     EXPECT_CALL(*notifier, NotifySongState(Field(&model::Song::CurrentInformation::position, _)))
         .Times(2);
 
+    // These are called by Player::ResetMediaControl()
     EXPECT_CALL(*decoder, ClearCache());
+    EXPECT_CALL(*notifier, NotifySongState(model::Song::CurrentInformation{
+                               .state = model::Song::MediaState::Finished}));
     EXPECT_CALL(*notifier, ClearSongInformation(true)).WillOnce(Invoke([&] {
       syncer.NotifyStep(4);
     }));

--- a/test/block_list_directory.cc
+++ b/test/block_list_directory.cc
@@ -593,6 +593,83 @@ TEST_F(ListDirectoryTest, PlayNextFileAfterFinished) {
 
 /* ********************************************************************************************** */
 
+TEST_F(ListDirectoryTest, StartPlayingLastFileAndPlayNextAfterFinished) {
+  InSequence seq;
+  auto derived = std::static_pointer_cast<interface::ListDirectory>(block);
+
+  // Setup expectation to play last file
+  std::filesystem::path file{LISTDIR_PATH + std::string{"/util_argparser.cc"}};
+  EXPECT_CALL(*dispatcher,
+              SendEvent(AllOf(Field(&interface::CustomEvent::id,
+                                    interface::CustomEvent::Identifier::NotifyFileSelection),
+                              Field(&interface::CustomEvent::content,
+                                    VariantWith<std::filesystem::path>(file)))))
+      .Times(1);
+
+  block->OnEvent(ftxui::Event::End);
+  block->OnEvent(ftxui::Event::Return);
+
+  ftxui::Render(*screen, block->Render());
+
+  std::string rendered = utils::FilterAnsiCommands(screen->ToString());
+
+  std::string expected = R"(
+╭ files ───────────────────────╮
+│test                          │
+│  ..                          │
+│  audio_player.cc             │
+│  block_file_info.cc          │
+│  block_list_directory.cc     │
+│  block_media_player.cc       │
+│  block_tab_viewer.cc         │
+│  CMakeLists.txt              │
+│  driver_fftw.cc              │
+│  general                     │
+│  middleware_media_controller.│
+│  mock                        │
+│> util_argparser.cc           │
+╰──────────────────────────────╯)";
+
+  EXPECT_THAT(rendered, StrEq(expected));
+
+  // Simulate player sending event to update song info and check internal state
+  auto event_update = interface::CustomEvent::UpdateSongInfo(model::Song{.filepath = file,
+                                                                         .artist = "Dummy artist",
+                                                                         .title = "Dummy title",
+                                                                         .num_channels = 2,
+                                                                         .sample_rate = 44100,
+                                                                         .bit_rate = 320000,
+                                                                         .bit_depth = 32,
+                                                                         .duration = 120});
+
+  derived->OnCustomEvent(event_update);
+  EXPECT_EQ(file, derived->curr_playing_.value());
+
+  // Simulate player sending event to notify that song has ended
+  auto event_finish = interface::CustomEvent::UpdateSongState(
+      model::Song::CurrentInformation{.state = model::Song::MediaState::Finished});
+
+  std::filesystem::path next_file{LISTDIR_PATH + std::string{"/audio_player.cc"}};
+
+  EXPECT_CALL(*dispatcher,
+              SendEvent(AllOf(Field(&interface::CustomEvent::id,
+                                    interface::CustomEvent::Identifier::NotifyFileSelection),
+                              Field(&interface::CustomEvent::content,
+                                    VariantWith<std::filesystem::path>(next_file)))))
+      .Times(1);
+
+  derived->OnCustomEvent(event_finish);
+
+  // Simulate player sending event with new song update
+  auto& content = std::get<model::Song>(event_update.content);
+  content.filepath = next_file;
+
+  derived->OnCustomEvent(event_update);
+  EXPECT_EQ(next_file, derived->curr_playing_.value());
+}
+
+/* ********************************************************************************************** */
+
 /**
  * @brief Tests with original ListDirectory class
  */


### PR DESCRIPTION
If current directory contains another files, spectrum will try to play next file when song finishes.